### PR TITLE
Fix Unmarshal

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -50,6 +50,12 @@ func NewEncoder(w io.Writer) *Encoder {
 // Deprecated: Do not use. This will be deleted in the near future.
 // See the "Use with the Standard Library" section for alternatives.
 func Unmarshal(data []byte, v interface{}) error {
+	ast, err := Parse(data)
+	if err != nil {
+		return err
+	}
+	ast.Standardize()
+	data = ast.Pack()
 	return json.Unmarshal(data, v)
 }
 

--- a/deprecated_test.go
+++ b/deprecated_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hujson
+
+import "testing"
+
+func TestUnmarshal(t *testing.T) {
+	var out interface{}
+	in := []byte("null\n//\n")
+	if err := Unmarshal(in, &out); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
The old HuJSON parser had a bug where it couldn't handle
trailing comments after the last value.
The new parser has no such problem.

As a quick fix to the deprecated Unmarshal function,
use the new parser to strip HuJSON-specific artifacts
and then pass the standardized output to Unmarshal.