### PR TITLE
Enable fuzz tests

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build dev.fuzz
-
 package hujson
 
 import (


### PR DESCRIPTION
Go 1.18 is now released.
The fuzz tests no longer need to be build tag protected.