### PR TITLE
Turn `ObjectMember` into a named type

### DIFF
--- a/types.go
+++ b/types.go
@@ -331,7 +331,7 @@ type Object struct {
 	// after the preceding open brace or comma and before the closing brace.
 	AfterExtra Extra
 }
-type ObjectMember = struct {
+type ObjectMember struct {
 	Name, Value Value
 }
 


### PR DESCRIPTION
I'm not sure why `ObjectMember` is defined as a type alias instead of a named type. In practice, it's probably not a big deal, but it makes autocomplete weird.