### PR TITLE
Add Standardize helper function

### DIFF
--- a/format.go
+++ b/format.go
@@ -9,6 +9,19 @@ import (
 	"unicode"
 )
 
+// Standardize strips any features specific to HuJSON from b,
+// making it compliant with standard JSON per RFC 8259.
+// All comments and trailing commas are replaced with a space character
+// in order to preserve the original line numbers and byte offsets.
+func Standardize(b []byte) ([]byte, error) {
+	ast, err := Parse(b)
+	if err != nil {
+		return b, err
+	}
+	ast.Standardize()
+	return ast.Pack(), nil
+}
+
 const punchCardWidth = 80
 
 var (

--- a/types.go
+++ b/types.go
@@ -71,12 +71,10 @@
 //
 // Example usage:
 //
-//	ast, err := hujson.Parse(b)
+//	b, err := hujson.Standardize(b)
 //	if err != nil {
 //		... // handle err
 //	}
-//	ast.Standardize()
-//	b = ast.Pack()
 //	if err := json.Unmarshal(b, &v); err != nil {
 //		... // handle err
 //	}


### PR DESCRIPTION
This reduces the boilerplate of using hujson with json.
We avoid a helper that directly wraps json.Unmarshal since
there could be a new json library in the future.
Let's avoid a dependency on the json Marshal/Unmarshal semantics
and keep this package purely about the HuJSON syntax.