### PR TITLE
turn comment into a standard Example()

### DIFF
--- a/types.go
+++ b/types.go
@@ -78,17 +78,7 @@
 // This package operates with HuJSON as an AST. In order to parse HuJSON
 // into arbitrary Go types, use this package to parse HuJSON input as an AST,
 // strip the AST of any HuJSON-specific lexicographical elements, and
-// then pack the AST as a standard JSON output.
-//
-// Example usage:
-//
-//	b, err := hujson.Standardize(b)
-//	if err != nil {
-//		... // handle err
-//	}
-//	if err := json.Unmarshal(b, &v); err != nil {
-//		... // handle err
-//	}
+// then pack the AST as a standard JSON output. See the Example.
 package hujson
 
 import (

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,32 @@
+package hujson_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tailscale/hujson"
+)
+
+func Example() {
+	humanBytes := []byte(`{
+		"author": "Strugatsky, Arkady and Boris",
+		"title":  "The Time Wanderers",
+		// my comment
+}`)
+
+	jsonBytes, err := hujson.Standardize(humanBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	result := map[string]any{}
+
+	if err := json.Unmarshal(jsonBytes, &result); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(result["author"])
+
+	// Output:
+	// Strugatsky, Arkady and Boris
+}


### PR DESCRIPTION
Use standard notation for testable Go examples. The example is still visible in the auto-generated godoc.

Note that from now on `go test .` will also check that the example still compiles and produces the same output.