### PR TITLE
Fix behavior of `hujsonfmt -l`

### DIFF
--- a/cmd/hujsonfmt/hujsonfmt.go
+++ b/cmd/hujsonfmt/hujsonfmt.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -118,7 +119,9 @@ func processFile(info fs.FileInfo, filename string, in io.Reader) error {
 	case *diff:
 		printDiff(filename, src, output)
 	case *list:
-		fmt.Println(filename)
+		if !bytes.Equal(input, output) {
+			fmt.Println(filename)
+		}
 	case *write:
 		err = writeFile(info, filename, src, output)
 		if err != nil {


### PR DESCRIPTION
The usage of `hujsonfmt` says that `hujsonfmt -l` only list files whose formatting differs from `hujsonfmt`'s, but the current behavior seems to list all files regardless of their formatting.  This PR attempts to fix that!